### PR TITLE
Multiple Widget Support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
         "ecmaVersion": "latest",
         "sourceType": "module"
     },
-//    "ignorePatterns": [".scratch/**/*", "widgets/**/*"],
+    "ignorePatterns": [".bubo/**/*"],
     "rules": {
         "semi": [2, "always"]
     }

--- a/README.md
+++ b/README.md
@@ -8,19 +8,16 @@ vx-bubo
 ```
 
 ```bash
-bubo --help 
-
-Usage: bubo [options]
+Usage: vx-bubo [options]
 
 Your guide to develop Thingsboard Widgets locally
 
 Options:
-  -h, --host <url>           ThingsBoard URL you wish to connect to if you opt to not set an env variable
-  -w, --widget <widiget-id>  specify the widget you would like to work with
-  -g, --get                  GET widget from ThingsBoard
-  -p, --push                 PUSH local widget ThingsBoard
-  -c, --clean                Clean local data such as host, token and widget id
-  --help                     display help for command
+  -g, --get             Get widget from ThingsBoard
+  -p, --push            Publish local widget ThingsBoard
+  -pm, --push-multiple  Publish Multiple local widgets to ThingsBoard
+  -c, --clean           Clean local data such as host, token and widget id
+  -h, --help            display help for command
 ```
 
 
@@ -33,3 +30,48 @@ Options:
   "widgetWorkingDirectory": "widgets"
 }
 ```
+
+## Menu Options
+```bash
+? 🦉 What would you like to do? (Use arrow keys)
+> Set ThingsBoard JWT token                     
+  Get Widget                                    
+  Publish Widget                                
+  Publish Multiple Widgets                      
+  Clear tokens and active widget id             
+🎟️ Copy JWT token from ThingsBoard              
+```
+
+### Set ThingsBoard JWT token
+
+```bash
+? 🦉 Lets get your Thingsboard Auth Token.
+    1) Login to ThingsBoard
+    2) Open this URL => https://thingsboardsite.com/security
+    3) Press the button "Copy JWT token" to copy the token to your clipboard
+        
+    Finished? (Y/n)
+```
+
+### Get Widget  
+```bash
+? 🦉 Would you like to get widget My Awesome Widget (00000000-0000-0000-0000-000000000000) ? (Y/n)
+
+```
+
+### Publish Widget    
+```bash
+? 🦉 Would you like to publish widget My Awesome Widget (00000000-0000-0000-0000-000000000000) ? (Y/n)
+
+```
+
+### Publish Multiple Widgets
+```bash
+? 🦉 What widgets would you like to publish? (Press <space> to select, <a> to toggle all, <i> to invert selection, and <enter> to proceed)
+>(*) My Awesome Widget undefined
+ (*) My Awesome Widget undefined
+ ( ) PMy Awesome Widget modified: 1 day ago
+
+```
+
+### Clear tokens and active widget id   

--- a/index.mjs
+++ b/index.mjs
@@ -5,7 +5,7 @@ import {
   promptMainMenu,
   promptPublishLocalWidgets,
   promptGetWidget,
-  promptPublishWidget
+  promptPublishModifiedWidgets
 } from './src/prompt.mjs';
 import { refreshToken, validToken } from './src/utils.mjs';
 import { getToken } from './src/session.mjs';
@@ -32,8 +32,8 @@ program
   .description('Your guide to develop Thingsboard Widgets locally')
   // .option('-b, --bundle', 'Bundle local widget')
   .option('-g, --get', 'Get widget from ThingsBoard')
-  .option('-p, --push', 'Publish local widget ThingsBoard')
-  .option('-pm, --push-multiple', 'Publish Multiple local widgets to ThingsBoard')
+  .option('-p, --push', 'Publish local widgets to ThingsBoard')
+  .option('-pm, --publish-modified', 'Publish all modified local widgets to ThingsBoard')
   .option('-c, --clean', 'Clean local data such as host, token and widget id');
 
 program.parse();
@@ -59,8 +59,8 @@ if (!getToken() || !validToken()) {
   await prompForToken();
 }
 
-if (options.pushMultiple) {
-  await promptPublishLocalWidgets();
+if (options.publishModified) {
+  await promptPublishModifiedWidgets();
 }
 
 // Get Widget from ThingsBoard
@@ -70,7 +70,7 @@ if (options.get) {
 
 // Publish Local Widget?
 if (options.push) {
-  await promptPublishWidget();
+  await promptPublishLocalWidgets();
 }
 
 async function showMainMenu () {

--- a/index.mjs
+++ b/index.mjs
@@ -40,10 +40,9 @@ program.parse();
 
 const options = program.opts();
 
-// Show Menu!
-if (getToken() && await !validToken()) {
-  await refreshToken();
-}
+// if (getToken() && await !validToken()) {
+//   await refreshToken();
+// }
 
 // No option selected, lets show main menu
 if (Object.keys(options).length === 0) {

--- a/index.mjs
+++ b/index.mjs
@@ -54,7 +54,7 @@ if (options.token) {
 }
 
 // Check for a token to continue
-if (!getToken() || !validToken()) {
+if (!validToken()) {
   await prompForToken();
 }
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { prompForToken, promptWidgetId, promptMenu, promptPublishLocalWidgets } from './src/prompt.mjs';
-import { validToken } from './src/utils.mjs';
-import { fetchAndSaveRemoteWidget, parseWidgetExport, publishLocalWidget } from './src/package.mjs';
-import { getToken, getActiveWidget } from './src/session.mjs';
+import {
+  prompForToken,
+  promptMainMenu,
+  promptPublishLocalWidgets,
+  promptGetWidget,
+  promptPublishWidget
+} from './src/prompt.mjs';
+import { refreshToken, validToken } from './src/utils.mjs';
+import { getToken } from './src/session.mjs';
 import path from 'path';
 import { cosmiconfig } from 'cosmiconfig';
 
@@ -17,69 +22,58 @@ export const tbHost = () => {
   return explorer.config.thingsBoardHost.trim().replace(/\/+$/g, '');
 };
 
+console.clear();
+
 // Go!
 const program = new Command();
+
 program
   .name('vx-bubo')
   .description('Your guide to develop Thingsboard Widgets locally')
-  .option('-w, --widget <widiget-id>', 'specify the widget you would like to work with')
   // .option('-b, --bundle', 'Bundle local widget')
-  .option('-g, --get', 'GET widget from ThingsBoard')
-  .option('-p, --push', 'PUSH local widget ThingsBoard')
+  .option('-g, --get', 'Get widget from ThingsBoard')
+  .option('-p, --push', 'Publish local widget ThingsBoard')
+  .option('-pm, --push-multiple', 'Publish Multiple local widgets to ThingsBoard')
   .option('-c, --clean', 'Clean local data such as host, token and widget id');
 
 program.parse();
+
 const options = program.opts();
 
-// No option selected, show main menu
+// Show Menu!
+if (getToken() && await !validToken()) {
+  await refreshToken();
+}
+
+// No option selected, lets show main menu
 if (Object.keys(options).length === 0) {
   await showMainMenu();
 }
 
 if (options.token) {
   await prompForToken();
-  await showMainMenu();
 }
 
 // Check for a token to continue
 if (!getToken() || !validToken()) {
   await prompForToken();
-  await showMainMenu();
-}
-
-if (options.widget) {
-  await promptWidgetId();
-  // await showMainMenu();
 }
 
 if (options.pushMultiple) {
   await promptPublishLocalWidgets();
-  // await showMainMenu();
 }
-
-let widgetId = await getActiveWidget();
 
 // Get Widget from ThingsBoard
 if (options.get) {
-  if (!widgetId) {
-    widgetId = await promptWidgetId();
-  }
-
-  await fetchAndSaveRemoteWidget(widgetId);
-  // Parse Widget Export for local development
-  await parseWidgetExport(widgetId);
-  console.log(`🦉 Widget ${widgetId} has been downloaded and ready to develop`);
-  // await showMainMenu();
+  await promptGetWidget();
 }
 
 // Publish Local Widget?
 if (options.push) {
-  await publishLocalWidget(widgetId);
-  // await showMainMenu();
+  await promptPublishWidget();
 }
 
 async function showMainMenu () {
-  const answer = await promptMenu();
+  const answer = await promptMainMenu();
   options[answer] = true;
-  // console.log(`🦉 You have made a wise choice ${answer}`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vx-bubo",
-  "version": "0.0.4",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vx-bubo",
-      "version": "0.0.4",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^3.3.0",
@@ -14,6 +14,7 @@
         "clipboardy": "^4.0.0",
         "commander": "^11.1.0",
         "cosmiconfig": "^8.3.6",
+        "date-fns": "^2.30.0",
         "eslint": "^8.53.0",
         "eslint-config-standard": "^17.1.0",
         "node-localstorage": "^3.0.5"
@@ -189,6 +190,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1028,6 +1040,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -2799,6 +2826,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clipboardy": "^4.0.0",
     "commander": "^11.1.0",
     "cosmiconfig": "^8.3.6",
+    "date-fns": "^2.30.0",
     "eslint": "^8.53.0",
     "eslint-config-standard": "^17.1.0",
     "node-localstorage": "^3.0.5"

--- a/src/package.mjs
+++ b/src/package.mjs
@@ -61,6 +61,7 @@ export const publishLocalWidget = async (widgetId) => {
   }
 
   let widgetJson = await getWidgetLocal(widgetJsonPath(widgetId));
+  const widgetName = widgetJson.name;
 
   // Process widget resources
   const resources = await processWidgetResources(widgetJson, outputAction);
@@ -95,7 +96,7 @@ export const publishLocalWidget = async (widgetId) => {
 
     // Update Local Widget Export
     await createFile(widgetJsonPath(widgetId), widgetJson);
-    console.log(chalk.green(`🦉 Widget ${widgetJson.name} has successfully been published`));
+    console.log(chalk.green(`🦉 Widget ${widgetName} has successfully been published`));
   }
 };
 

--- a/src/package.mjs
+++ b/src/package.mjs
@@ -13,6 +13,7 @@ import {
 import { localWidgetPath, scratchPath, tbHost } from '../index.mjs';
 import chalk from 'chalk';
 
+// Helpers
 export const widgetJsonPath = (widgetId) => {
   if (!widgetId) {
     throw new Error('Specify a widgetId');
@@ -20,6 +21,51 @@ export const widgetJsonPath = (widgetId) => {
   return path.join(scratchPath, 'widgets', `${widgetId}.json`);
 };
 
+const resourcesWriteMap = [
+  {
+    property: 'controllerScript',
+    extension: 'js'
+  },
+  {
+    property: 'templateHtml',
+    extension: 'html'
+  },
+  {
+    property: 'templateCss',
+    extension: 'css'
+  },
+  {
+    property: 'settingsSchema',
+    extension: 'json',
+    name: 'settingsSchema'
+  },
+  {
+    property: 'dataKeySettingsSchema',
+    extension: 'json',
+    name: 'dataKeySettingsSchema'
+  }
+];
+
+const actionWriteMap = [
+  {
+    property: 'customFunction',
+    extension: 'js'
+  },
+  {
+    property: 'customHtml',
+    extension: 'html'
+  },
+  {
+    property: 'customCss',
+    extension: 'css'
+  }
+  // {
+  //   property: 'showWidgetActionFunction',
+  //   extension: 'js',
+  // }
+];
+
+// Actions
 export const fetchAndSaveRemoteWidget = async (widgetId) => {
   if (!widgetId) {
     throw new Error('Specify a widgetId');
@@ -54,12 +100,10 @@ export const parseWidgetExport = async (widgetId) => {
 };
 
 export const publishLocalWidget = async (widgetId) => {
-  const outputAction = 'bundle';
-
   if (!widgetId) {
     throw new Error('Specify a widgetId');
   }
-
+  const outputAction = 'bundle';
   let widgetJson = await getWidgetLocal(widgetJsonPath(widgetId));
   const widgetName = widgetJson.name;
 
@@ -99,50 +143,6 @@ export const publishLocalWidget = async (widgetId) => {
     console.log(chalk.green(`🦉 Widget ${widgetName} has successfully been published`));
   }
 };
-
-const resourcesWriteMap = [
-  {
-    extension: 'js',
-    property: 'controllerScript'
-  },
-  {
-    extension: 'html',
-    property: 'templateHtml'
-  },
-  {
-    extension: 'css',
-    property: 'templateCss'
-  },
-  {
-    extension: 'json',
-    property: 'settingsSchema',
-    name: 'settingsSchema'
-  },
-  {
-    extension: 'json',
-    property: 'dataKeySettingsSchema',
-    name: 'dataKeySettingsSchema'
-  }
-];
-
-const actionWriteMap = [
-  {
-    extension: 'js',
-    property: 'customFunction'
-  },
-  {
-    extension: 'html',
-    property: 'customHtml'
-  },
-  {
-    extension: 'css',
-    property: 'customCss'
-  },
-  {
-    extension: 'js',
-    property: 'showWidgetActionFunction'
-  }
-];
 
 const processActions = async (widgetJson, output) => {
   const actionsFormatted = JSON.parse(widgetJson.descriptor.defaultConfig);

--- a/src/package.mjs
+++ b/src/package.mjs
@@ -95,7 +95,7 @@ export const publishLocalWidget = async (widgetId) => {
 
     // Update Local Widget Export
     await createFile(widgetJsonPath(widgetId), widgetJson);
-    console.log(chalk.green('🦉 Widget has successfully been published'));
+    console.log(chalk.green(`🦉 Widget ${widgetJson.name} has successfully been published`));
   }
 };
 

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -35,17 +35,18 @@ export const promptMainMenu = async () => {
         disabled: (disableHost || disableToken)
       },
       {
-        name: 'Publish Widget',
+        name: 'Publish Widgets',
         value: 'push',
-        description: '🚀 PUSH active widget',
+        description: '🚀 Publish Widgets to ThingsBoard',
         disabled: (disableHost || disableToken)
       },
       {
-        name: 'Publish Multiple Widgets',
-        value: 'pushMultiple',
-        description: '🚀 PUSH Multiple Widgets',
+        name: 'Publish Modified Widgets',
+        value: 'publishModified',
+        description: '🤖🚀 Publish modified widgets',
         disabled: (disableHost || disableToken)
       },
+
       // {
       //   name: 'bundle',
       //   value: 'bundle',
@@ -124,22 +125,14 @@ export const promptGetWidget = async () => {
   }
 };
 
-export const promptPublishWidget = async () => {
-  const widgetId = await getActiveWidget();
-  let promptPublishAction;
+export const promptPublishModifiedWidgets = async () => {
+  const localWidgets = await findLocalWidgetsWithModifiedAssets();
 
-  if (widgetId) {
-    const widgetJson = await getWidgetLocal(path.join(scratchPath, 'widgets', `${widgetId}.json`));
-    promptPublishAction = await confirm({
-      name: 'publish',
-      message: `🦉 Would you like to publish widget ${chalk.bold.green(widgetJson.name)} (${chalk.reset.yellow(widgetId)}) ?`
-    }, clearPrevious);
-  }
-  if (promptPublishAction) {
-    await publishLocalWidget(widgetId);
-  } else {
-    await promptPublishLocalWidgets();
-  }
+  const modifiedWidgets = localWidgets.filter((widget) => widget?.assetsModified);
+
+  modifiedWidgets.map(async (widget) => {
+    return await publishLocalWidget(widget.id);
+  });
 };
 
 export const promptPublishLocalWidgets = async () => {

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -92,12 +92,14 @@ export const promptGetWidget = async () => {
   if (widgetId) {
     const widgetLocalJsonPath = path.join(scratchPath, 'widgets', `${widgetId}.json`);
     let widgetJson;
+    let messageChunk = `id: ${widgetId} ${chalk.red('unable to locate local json.')}`;
     if (await checkPath(widgetLocalJsonPath)) {
       widgetJson = await getWidgetLocal();
+      messageChunk = `${chalk.bold.green(widgetJson.name)} (${chalk.reset.yellow(widgetId)})`;
     }
     promptGetAction = await confirm({
       name: 'widgetId',
-      message: `🦉 Would you like to get widget ${chalk.bold.green(widgetJson.name)} (${widgetJson ? chalk.reset.yellow(widgetId) : ''}) ?`
+      message: `🦉 Would you like to get widget  ${messageChunk}?`
     }, clearPrevious);
   }
   if (!promptGetAction) {

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -136,11 +136,15 @@ export const promptPublishModifiedWidgets = async () => {
   const localWidgets = await findLocalWidgetsWithModifiedAssets();
 
   const modifiedWidgets = localWidgets.filter((widget) => widget?.assetsModified);
-  Promise.all(
-    modifiedWidgets.map(async (widget) => {
-      return await publishLocalWidget(widget.id);
-    })
-  );
+  if (modifiedWidgets) {
+    await Promise.all(
+      modifiedWidgets.map(async (widget) => {
+        return await publishLocalWidget(widget.id);
+      })
+    );
+  } else {
+    console.log(chalk.yellowBright('🦉 No changes to widgets found.'));
+  }
   goodbye();
 };
 
@@ -152,7 +156,7 @@ export const promptPublishLocalWidgets = async () => {
     choices: widgetChoices
   }, clearPrevious);
 
-  Promise.all(
+  await Promise.all(
     answer.map(async (widget) => {
       return await publishLocalWidget(widget.id);
     })

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -1,6 +1,7 @@
 import { input, select, confirm, checkbox } from '@inquirer/prompts';
 import clipboard from 'clipboardy';
 import {
+  checkPath,
   findLocalWidgetsWithModifiedAssets,
   getUserRefreshToken, getWidgetLocal,
   validToken
@@ -17,7 +18,6 @@ const clearPrevious = { clearPromptOnDone: true };
 export const promptMainMenu = async () => {
   const disableToken = await validToken() === false;
   const disableHost = tbHost() === null;
-  const disableWidget = getActiveWidget() === null;
 
   const answer = await select({
     message: '🦉 What would you like to do?',
@@ -32,13 +32,13 @@ export const promptMainMenu = async () => {
         name: 'Get Widget',
         value: 'get',
         description: '⚡️ Get a widget from ThingsBoard using the widgetId',
-        disabled: (disableHost || disableToken || disableWidget)
+        disabled: (disableHost || disableToken)
       },
       {
         name: 'Publish Widget',
         value: 'push',
         description: '🚀 PUSH active widget',
-        disabled: (disableHost || disableToken || disableWidget)
+        disabled: (disableHost || disableToken)
       },
       {
         name: 'Publish Multiple Widgets',
@@ -90,10 +90,14 @@ export const promptGetWidget = async () => {
   let promptGetAction;
 
   if (widgetId) {
-    const widgetJson = await getWidgetLocal(path.join(scratchPath, 'widgets', `${widgetId}.json`));
+    const widgetLocalJsonPath = path.join(scratchPath, 'widgets', `${widgetId}.json`);
+    let widgetJson;
+    if (await checkPath(widgetLocalJsonPath)) {
+      widgetJson = await getWidgetLocal();
+    }
     promptGetAction = await confirm({
       name: 'widgetId',
-      message: `🦉 Would you like to get widget ${chalk.bold.green(widgetJson.name)} (${chalk.reset.yellow(widgetId)}) ?`
+      message: `🦉 Would you like to get widget ${chalk.bold.green(widgetJson.name)} (${widgetJson ? chalk.reset.yellow(widgetId) : ''}) ?`
     }, clearPrevious);
   }
   if (!promptGetAction) {

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -94,7 +94,7 @@ export const promptGetWidget = async () => {
     let widgetJson;
     let messageChunk = `id: ${widgetId} ${chalk.red('unable to locate local json.')}`;
     if (await checkPath(widgetLocalJsonPath)) {
-      widgetJson = await getWidgetLocal();
+      widgetJson = await getWidgetLocal(widgetLocalJsonPath);
       messageChunk = `${chalk.bold.green(widgetJson.name)} (${chalk.reset.yellow(widgetId)})`;
     }
     promptGetAction = await confirm({

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -146,7 +146,7 @@ export const promptPublishLocalWidgets = async () => {
   const localWidgets = await findLocalWidgetsWithModifiedAssets();
 
   const widgetChoices = localWidgets.map((widget) => {
-    let modifiedAgo;
+    let modifiedAgo = '';
     if (widget?.assetsModified) {
       modifiedAgo = chalk.italic.dim.yellow(`modified: ${formatDistanceToNow(widget.assetsModified)} ago`);
     }

--- a/src/session.mjs
+++ b/src/session.mjs
@@ -11,7 +11,8 @@ export const getRefreshToken = () => {
 };
 
 export const getActiveWidget = () => {
-  return localStorage.getItem('widgetId').trim();
+  const widgetId = localStorage.getItem('widgetId');
+  return widgetId ? widgetId.trim() : widgetId;
 };
 
 export default localStorage;

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -11,7 +11,7 @@ export const authHeaders = (token) => {
   };
 };
 
-export const fetchHandler = async (url, params) => {
+export const fetchHandler = async (url, params = {}) => {
   // Check if the token is expired or will expire soon refresh token.
   if (isTokenExpired()) {
     console.log('Token is expired, refreshing..');
@@ -182,8 +182,8 @@ export const findLocalWidgetsWithModifiedAssets = async () => {
           const widgetAssetPath = path.join(widgetPath, widgetAsset);
           const stats = fs.statSync(widgetAssetPath);
 
-          if ((stats.mtime > widget.modified) || (stats.mtime > widget.assetsModified)) {
-            widget.assetsModified = stats.mtime;
+          if (stats.mtime > widget.modified) {
+            if (stats.mtime > widget.assetsModified || !widget.assetsModified) widget.assetsModified = stats.mtime;
           }
         }
       }

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -57,7 +57,7 @@ export const refreshToken = async () => {
     })
   };
   const request = await fetch(`${tbHost()}/api/auth/token`, { ...params });
-  if (request.status !== 200) {
+  if (request.status === 200) {
     const response = await request.json();
     if (response.token) {
       localStorage.setItem('token', `Bearer ${response.token}`);
@@ -65,8 +65,8 @@ export const refreshToken = async () => {
     if (response.refreshToken) {
       localStorage.setItem('refreshToken', response.refreshToken);
     }
-    return getToken();
   }
+  return getToken();
 };
 
 export const getUserRefreshToken = async () => {

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -46,6 +46,7 @@ export const isTokenExpired = () => {
 export const refreshToken = async () => {
   const params = {
     headers: {
+      Authorization: getToken(),
       Accept: 'application/json',
       'Content-Type': 'application/json'
     },
@@ -55,7 +56,7 @@ export const refreshToken = async () => {
     })
   };
   // TODO: Verify this
-  const request = await fetch(`${tbHost()}/api/auth/token`, { ...authHeaders(), ...params });
+  const request = await fetch(`${tbHost()}/api/auth/token`, { ..params });
   const response = await request.json();
   if (response.token) {
     localStorage.setItem('token', `Bearer ${response.token}`);
@@ -79,7 +80,7 @@ export const getUserRefreshToken = async () => {
 export const validToken = async (token) => {
   token = token || getToken();
   if (!token || !tbHost()) {
-    // console.debug('No Token');
+    console.debug('No Token');
     return false;
   }
   const request = await fetch(`${tbHost()}/api/auth/user`, { ...authHeaders(token) });
@@ -88,7 +89,7 @@ export const validToken = async (token) => {
     console.log('testToken Failed =>', request.status, response.message);
     // TODO: Abstract this away, no localStorage direct calls
     // Remove token if failed/expired
-    localStorage.removeItem('token');
+    await refreshToken();
     return false;
   }
   return true;

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -20,9 +20,9 @@ export const fetchHandler = async (url, params) => {
   // TODO : Improve this.
   const auth = authHeaders();
   if (params?.headers) {
-    params.headers = { ...auth?.headers, ...params?.headers };
+    params.headers = { ...auth.headers, ...params?.headers };
   } else {
-    params.headers = auth;
+    params.headers = { ...auth.headers };
   }
   return await fetch(url, { ...params });
 };

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -55,7 +55,6 @@ export const refreshToken = async () => {
       refreshToken: getRefreshToken()
     })
   };
-  // TODO: Verify this
   const request = await fetch(`${tbHost()}/api/auth/token`, { ...params });
   const response = await request.json();
   if (response.token) {

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -17,9 +17,13 @@ export const fetchHandler = async (url, params) => {
     console.log('Token is expired, refreshing..');
     await refreshToken();
   }
-  // TODO : Improve dis.
+  // TODO : Improve this.
   const auth = authHeaders();
-  params.headers = { ...auth?.headers, ...params?.headers };
+  if (params?.headers) {
+    params.headers = { ...auth?.headers, ...params?.headers };
+  } else {
+    params.headers = auth;
+  }
   return await fetch(url, { ...params });
 };
 
@@ -50,7 +54,7 @@ export const refreshToken = async () => {
       refreshToken: getRefreshToken()
     })
   };
-
+  // TODO: Verify this
   const request = await fetch(`${tbHost()}/api/auth/token`, { ...authHeaders(), ...params });
   const response = await request.json();
   if (response.token) {

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -56,7 +56,7 @@ export const refreshToken = async () => {
     })
   };
   // TODO: Verify this
-  const request = await fetch(`${tbHost()}/api/auth/token`, { ..params });
+  const request = await fetch(`${tbHost()}/api/auth/token`, { ...params });
   const response = await request.json();
   if (response.token) {
     localStorage.setItem('token', `Bearer ${response.token}`);
@@ -64,7 +64,7 @@ export const refreshToken = async () => {
   if (response.refreshToken) {
     localStorage.setItem('refreshToken', response.refreshToken);
   }
-  // console.log('refreshToken => ', response);
+  return true;
 };
 
 export const getUserRefreshToken = async () => {


### PR DESCRIPTION
- Adds support for publishing multiple widgets
- Includes checking for filesystem changes

```bash
? 🦉 What would you like to do? (Use arrow keys)
> Set ThingsBoard JWT token                     
  Get Widget                                    
  Publish Widget                                
  Publish Multiple Widgets                      
  Clear tokens and active widget id             
🎟️ Copy JWT token from ThingsBoard
```

```bash
? 🦉 What widgets would you like to publish? (Press <space> to select, <a> to toggle all, <i> to invert selection, and <enter> to proceed)
>( ) Jobs Entities Table modified: about 2 hours ago 




```